### PR TITLE
chore: scaffold OSS governance, CI, and templates

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,9 @@
+# Default owners
+* @vinnycarpenter
+
+# Critical paths (example granularity; adjust as needed)
+src/infrastructure.ts @vinnycarpenter
+scripts/ @vinnycarpenter
+types/ @vinnycarpenter
+tools/ @vinnycarpenter
+

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,32 @@
+name: Bug report
+description: File a bug report
+labels: [bug]
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Describe the bug
+      description: A clear and concise description of the problem.
+      placeholder: What happened? What did you expect?
+    validations:
+      required: true
+  - type: textarea
+    id: repro
+    attributes:
+      label: Reproduction steps
+      description: Steps to reproduce the behavior.
+      placeholder: 1) command 2) config 3) result
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: Version
+      description: Output of `node -v` and project version.
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs
+      description: Relevant logs (use `src/utils/logger.ts` for runtime logs).
+      render: shell
+

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,28 @@
+name: Feature request
+description: Suggest an idea for this project
+labels: [enhancement]
+body:
+  - type: textarea
+    id: motivation
+    attributes:
+      label: Motivation
+      description: What problem does this solve?
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposal
+      description: Describe the solution you'd like.
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives
+      description: Any alternative solutions or features you've considered.
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional context
+

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,29 @@
+## Summary
+
+Describe the change. Why is it needed?
+
+## Type of change
+
+- [ ] feat
+- [ ] fix
+- [ ] docs
+- [ ] refactor
+- [ ] test
+- [ ] chore
+
+## How to test
+
+Commands to build/test and expected outcomes.
+
+## Checklist
+
+- [ ] Follows Conventional Commits
+- [ ] Lint, build, and unit tests pass
+- [ ] Docs updated (if needed)
+- [ ] No sensitive info or secrets
+- [ ] Code Owners reviewed
+
+## Breaking changes
+
+If applicable, describe impact and migration notes.
+

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,19 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: chore
+      include: scope
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: chore
+      include: scope
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,70 @@
+name: CI
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+    branches: [main]
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18
+          cache: npm
+      - name: Install
+        run: npm ci
+      - name: Lint
+        run: npm run lint
+
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    needs: lint
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18
+          cache: npm
+      - name: Install
+        run: npm ci
+      - name: Build
+        run: npm run build
+
+  test-unit:
+    name: Unit tests
+    runs-on: ubuntu-latest
+    needs: build
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18
+          cache: npm
+      - name: Install
+        run: npm ci
+      - name: Test
+        run: npm run test:unit -- --coverage
+

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,54 @@
+# Code of Conduct
+
+This project adopts the Contributor Covenant Code of Conduct, version 2.1.
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, religion, or sexual identity
+and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment include:
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+- Focusing on what is best for the community
+
+Examples of unacceptable behavior include:
+- The use of sexualized language or imagery, and sexual attention or advances
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others’ private information without explicit permission
+- Other conduct which could reasonably be considered inappropriate
+
+## Enforcement Responsibilities
+
+Project maintainers are responsible for clarifying and enforcing our standards
+of acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+## Scope
+
+This Code of Conduct applies within all community spaces and also applies when
+an individual is officially representing the community.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by opening a private security advisory or contacting the maintainer at
+security@your-domain.example. All complaints will be reviewed and investigated
+promptly and fairly.
+
+## Attribution
+
+This Code of Conduct is adapted from the Contributor Covenant,
+version 2.1, available at https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,47 @@
+# Contributing
+
+Thanks for your interest in contributing! This project is open to community contributions with a maintainer-driven merge policy: contributions are reviewed via Pull Requests and merged by the maintainer only.
+
+## Quick Start
+
+- Node.js LTS and npm installed
+- Install deps: `npm ci`
+- Build: `npm run build`
+- Lint: `npm run lint`
+- Unit tests: `npm run test:unit`
+- Integration tests (may require AWS):
+  - Setup: `npm run test:integration:setup`
+  - Run: `npm run test:integration:run`
+
+Follow repository conventions:
+- Source in `src/` (entry `index.ts`); tests in `tests/`
+- Prefer `src/utils/logger.ts` over `console` for runtime logs
+- Use TypeScript with 2-space indentation
+
+## Branching and Commits
+
+- Create feature branches from `main` (e.g., `feature/xyz-improvement`)
+- Use Conventional Commits for messages (e.g., `feat: add cost analyzer`)
+- Keep PRs focused and small when possible
+
+## Pull Request Guidelines
+
+- Include what/why, linked issues, and testing instructions
+- Add/adjust unit tests; target ≥80% coverage for new code
+- Update docs when behavior or public APIs change
+- CI must be green: lint, build, and unit tests must pass
+- Code Owners review is required; only the maintainer merges PRs
+
+## Security
+
+Do not report security issues in public issues or PRs. Use the process in `SECURITY.md`.
+
+## CI Notes for External Contributors
+
+- CI runs `lint`, `build`, and `test:unit` on PRs
+- Integration tests are not run on untrusted forks
+
+## Releasing
+
+Releases are manual. See `docs/RELEASING.md`.
+

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,0 +1,19 @@
+# Governance
+
+This project uses a lightweight, maintainer-driven governance model.
+
+## Roles
+
+- Maintainer: Has merge and release rights; triages issues and reviews PRs.
+- Contributor: Anyone submitting issues, PRs, or feedback.
+
+## Decision Making
+
+- Lazy consensus for routine changes after review.
+- The maintainer has final say on design and roadmap.
+
+## Merging
+
+- All changes land via Pull Request with passing CI and required reviews.
+- Only the maintainer merges PRs to `main`.
+

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,22 @@
+MIT License
+
+Copyright (c) 2025 Vinny Carpenter
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,6 @@
+# Maintainers
+
+- Vinny Carpenter (@vinnycarpenter)
+
+Contact: security@your-domain.example
+

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,24 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+Please report security issues privately to the maintainer:
+
+- Preferred: Open a private report via GitHub Security Advisories
+- Alternate: Email security@your-domain.example
+
+We aim to acknowledge reports within 2 business days and resolve critical
+issues as quickly as possible. Please do not disclose vulnerabilities publicly
+until a fix is released.
+
+## Supported Versions
+
+Security fixes are typically provided for the latest main branch and the most
+recent tagged release.
+
+## Disclosure Policy
+
+- We confirm the issue and assess impact/severity.
+- We develop and test a fix.
+- We coordinate a release and publish an advisory crediting the reporter.
+

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -1,0 +1,19 @@
+# Releasing (Manual)
+
+This project uses manual releases controlled by the maintainer.
+
+## Checklist
+
+1) Ensure `main` is green (CI passing) and up to date
+2) Update version in `package.json` using SemVer (patch/minor/major)
+3) Update `CHANGELOG.md` (optional but recommended)
+4) Build locally: `npm ci && npm run build && npm run test:unit`
+5) Tag the release locally: `git tag -s vX.Y.Z && git push origin vX.Y.Z`
+6) Create a GitHub Release for the tag with notes
+7) If publishing to npm, enable 2FA and provenance and run `npm publish`
+
+## Notes
+
+- Only the maintainer should perform releases.
+- Sign tags when possible and protect release tags on GitHub (e.g., `v*`).
+


### PR DESCRIPTION
This PR scaffolds open-source essentials and hardened CI.

- Add MIT LICENSE
- Add Code of Conduct, Contributing, Security, Governance, Maintainers
- Add CODEOWNERS and PR/Issue templates
- Add Dependabot configuration (npm + actions, weekly)
- Add hardened CI workflow (lint, build, unit tests)
- Add manual releasing docs

Repo settings to adjust post-merge:
- Protect main: require PRs, up-to-date branches, 1+ review, Code Owners, and required checks (Lint, Build, Unit tests)
- Enable Dependabot alerts and secret scanning
- Protect release tags (v*) and prefer signed tags

Only the maintainer merges PRs per GOVERNANCE.md.
