### PR TITLE
docs: add live deployment test and verification; deployment QA improvements

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -17,5 +17,6 @@ module.exports = {
   coverageReporters: ['text', 'lcov', 'html'],
   setupFilesAfterEnv: ['<rootDir>/tests/setup.ts'],
   moduleFileExtensions: ['ts', 'js', 'json'],
-  verbose: true
+  verbose: true,
+  watchman: false
 };

--- a/package.json
+++ b/package.json
@@ -20,6 +20,8 @@
     "validate:pre-deploy": "./scripts/pre-deployment-check.sh",
     "validate:ios": "./scripts/validate-ios-config.sh",
     "validate:deployment": "./scripts/validate-deployment.sh",
+    "verify:lambda-bundle": "./scripts/verify-deployed-bundle.sh",
+    "test:deployment": "./scripts/test-deployment.sh",
     "validate:all": "npm run validate:config && npm run validate:pre-deploy",
     "lint": "eslint src/**/*.ts",
     "clean": "rm -rf dist coverage",
@@ -31,12 +33,11 @@
     "@aws-sdk/client-dynamodb": "^3.888.0",
     "@aws-sdk/client-lambda": "^3.450.0",
     "@aws-sdk/client-sns": "^3.450.0",
-    "@aws-sdk/util-dynamodb": "^3.888.0",
-    "aws-cdk-lib": "^2.100.0",
-    "constructs": "^10.0.0",
-    "strands-agents": "^0.0.1"
+    "@aws-sdk/util-dynamodb": "^3.888.0"
   },
   "devDependencies": {
+    "aws-cdk-lib": "^2.100.0",
+    "constructs": "^10.0.0",
     "@types/jest": "^29.0.0",
     "@types/node": "^20.0.0",
     "@typescript-eslint/eslint-plugin": "^6.0.0",

--- a/scripts/test-deployment.sh
+++ b/scripts/test-deployment.sh
@@ -1,0 +1,147 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# Test the deployed Spend Monitor Lambda by temporarily lowering SPEND_THRESHOLD,
+# invoking the function, checking logs for alert markers, and restoring env vars.
+
+usage() {
+  cat << EOF
+Usage: $0 [options]
+
+Options:
+  -f, --function-name NAME   Lambda function name (overrides stack lookup)
+  -s, --stack-name NAME      CloudFormation stack name (default: SpendMonitorStack)
+  -r, --region REGION        AWS region (default: env or us-east-1)
+  --since MINUTES            Minutes back for log scan (default: 10)
+  --keep-threshold           Do not restore original SPEND_THRESHOLD
+  -h, --help                 Show this help
+
+Examples:
+  $0 --stack-name SpendMonitorStack
+  $0 --function-name SpendMonitorStack-SpendMonitorAgentV2-ABC123 --since 15
+EOF
+}
+
+STACK_NAME=${STACK_NAME:-SpendMonitorStack}
+REGION=${AWS_REGION:-${CDK_DEFAULT_REGION:-us-east-1}}
+SINCE_MIN=10
+KEEP_THRESHOLD=false
+FN=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -f|--function-name)
+      FN="$2"; shift 2;;
+    -s|--stack-name)
+      STACK_NAME="$2"; shift 2;;
+    -r|--region)
+      REGION="$2"; shift 2;;
+    --since)
+      SINCE_MIN="$2"; shift 2;;
+    --keep-threshold)
+      KEEP_THRESHOLD=true; shift;;
+    -h|--help)
+      usage; exit 0;;
+    *)
+      echo "Unknown option: $1" >&2; usage; exit 1;;
+  esac
+done
+
+require_cmd() { command -v "$1" >/dev/null 2>&1 || { echo "[ERROR] Missing dependency: $1" >&2; exit 1; }; }
+
+require_cmd aws
+require_cmd jq
+
+echo "[INFO] Region: $REGION"
+
+# Resolve function name from stack output if not provided
+if [[ -z "$FN" ]]; then
+  echo "[INFO] Resolving Lambda function name from stack: $STACK_NAME"
+  FN=$(aws cloudformation describe-stacks \
+    --stack-name "$STACK_NAME" \
+    --region "$REGION" \
+    --query "Stacks[0].Outputs[?OutputKey=='AgentFunctionName'].OutputValue" \
+    --output text)
+fi
+
+if [[ -z "$FN" || "$FN" == "None" ]]; then
+  echo "[ERROR] Could not resolve Lambda function name. Use --function-name." >&2
+  exit 1
+fi
+
+echo "[INFO] Testing Lambda: $FN"
+
+TMP_DIR=$(mktemp -d)
+ORIG_ENV_JSON="$TMP_DIR/orig-env.json"
+MOD_ENV_JSON="$TMP_DIR/mod-env.json"
+RESP_JSON="$TMP_DIR/response.json"
+
+cleanup() {
+  [[ -d "$TMP_DIR" ]] && rm -rf "$TMP_DIR" || true
+}
+trap cleanup EXIT
+
+echo "[INFO] Fetching current environment variables..."
+aws lambda get-function-configuration \
+  --function-name "$FN" \
+  --region "$REGION" \
+  --query 'Environment.Variables' \
+  --output json > "$ORIG_ENV_JSON"
+
+CURRENT_THRESHOLD=$(jq -r '.SPEND_THRESHOLD // ""' "$ORIG_ENV_JSON")
+echo "[INFO] Current SPEND_THRESHOLD: ${CURRENT_THRESHOLD:-<unset>}"
+
+echo "[INFO] Setting SPEND_THRESHOLD to 0.01 for test..."
+jq '.SPEND_THRESHOLD = "0.01"' "$ORIG_ENV_JSON" | jq '{Variables: .}' > "$MOD_ENV_JSON"
+aws lambda update-function-configuration \
+  --function-name "$FN" \
+  --region "$REGION" \
+  --environment file://"$MOD_ENV_JSON" >/dev/null
+
+echo "[INFO] Invoking Lambda..."
+aws lambda invoke \
+  --function-name "$FN" \
+  --region "$REGION" \
+  --payload '{}' "$RESP_JSON" >/dev/null
+
+echo "[INFO] Invocation result:"
+cat "$RESP_JSON" || true
+echo
+
+echo "[INFO] Scanning logs for alert/threshold messages (last ${SINCE_MIN}m)..."
+if aws logs tail /aws/lambda/spend-monitor-agent \
+  --region "$REGION" \
+  --since "${SINCE_MIN}m" \
+  --filter-pattern 'Spending threshold exceeded|Alert sent successfully|Simplified alert sent successfully' \
+  --format short >/dev/null 2>&1; then
+  aws logs tail /aws/lambda/spend-monitor-agent \
+    --region "$REGION" \
+    --since "${SINCE_MIN}m" \
+    --filter-pattern 'Spending threshold exceeded|Alert sent successfully|Simplified alert sent successfully' \
+    --format short
+else
+  echo "[WARN] Could not tail logs (aws logs tail not supported); falling back to filter-log-events"
+  START_MS=$(( ( $(date +%s) - (SINCE_MIN*60) ) * 1000 ))
+  aws logs filter-log-events \
+    --region "$REGION" \
+    --log-group-name /aws/lambda/spend-monitor-agent \
+    --start-time "$START_MS" \
+    --query 'events[].message' \
+    --output text | grep -E 'Spending threshold exceeded|Alert sent successfully|Simplified alert sent successfully' || true
+fi
+
+if [[ "$KEEP_THRESHOLD" != true ]]; then
+  echo "[INFO] Restoring original SPEND_THRESHOLD (${CURRENT_THRESHOLD:-<unset>})..."
+  jq '{Variables: .}' "$ORIG_ENV_JSON" > "$MOD_ENV_JSON"
+  aws lambda update-function-configuration \
+    --function-name "$FN" \
+    --region "$REGION" \
+    --environment file://"$MOD_ENV_JSON" >/dev/null
+  echo "[INFO] Restoration complete."
+else
+  echo "[INFO] Keeping modified SPEND_THRESHOLD as requested."
+fi
+
+echo "[DONE] Deployment test completed."
+

--- a/scripts/verify-deployed-bundle.sh
+++ b/scripts/verify-deployed-bundle.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if [[ $# -lt 1 ]]; then
+  echo "Usage: $0 <lambda-function-name> [region]" >&2
+  exit 1
+fi
+
+FUNCTION_NAME="$1"
+REGION="${2:-${AWS_REGION:-${CDK_DEFAULT_REGION:-us-east-1}}}"
+
+TMP_DIR="$(mktemp -d)"
+ZIP_PATH="$TMP_DIR/code.zip"
+
+echo "[INFO] Inspecting deployed Lambda bundle for: $FUNCTION_NAME (region: $REGION)"
+
+if ! command -v aws >/dev/null 2>&1; then
+  echo "[ERROR] AWS CLI not found. Please install and configure AWS CLI." >&2
+  exit 1
+fi
+
+echo "[INFO] Fetching code location..."
+CODE_URL=$(aws lambda get-function \
+  --function-name "$FUNCTION_NAME" \
+  --region "$REGION" \
+  --query 'Code.Location' \
+  --output text)
+
+echo "[INFO] Downloading bundle to $ZIP_PATH ..."
+curl -sSL "$CODE_URL" -o "$ZIP_PATH"
+
+echo "[INFO] Unzipping..."
+unzip -q "$ZIP_PATH" -d "$TMP_DIR/unzipped"
+
+echo "[INFO] Searching for 'strands-agents' in deployed code..."
+if rg -n "strands-agents" "$TMP_DIR/unzipped" >/dev/null 2>&1; then
+  echo "[ERROR] Found unexpected 'strands-agents' reference in deployed bundle:"
+  rg -n "strands-agents" "$TMP_DIR/unzipped" || true
+  echo "[HINT] This indicates a stale artifact. Rebuild, resync dist -> fresh-deployment, and redeploy."
+  exit 2
+else
+  echo "[OK] No references to 'strands-agents' found in deployed bundle."
+fi
+
+echo "[INFO] Sample top-level files:"
+ls -la "$TMP_DIR/unzipped" | head -n 40
+
+echo "[DONE] Inspection complete. Temp dir: $TMP_DIR"
+echo "       Remove it with: rm -rf $TMP_DIR"
+

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -45,7 +45,7 @@ jest.mock('strands-agents', () => ({
   Task: class MockTask {
     constructor(public name: string, public description: string) {}
   }
-}));
+}), { virtual: true });
 
 // Set up environment variables for tests
 process.env.AWS_REGION = 'us-east-1';


### PR DESCRIPTION
Title: docs: add live deployment test and verification; deployment QA improvements

Summary
- Adds live deployment verification steps and scripts to validate Lambda behavior post-deploy.
- Documents scripts/test-deployment.sh usage to force alert-path validation and scan logs.
- Adds scripts/verify-deployed-bundle.sh to guard against stale artifacts (e.g., stray requires).
- Tightens deploy flow to sync dist → fresh-deployment and install prod-only deps to avoid Lambda size errors.

Changes
- README.md:
  - Post-deploy verification and troubleshooting sections.
  - Live Deployment Test (Alert Path) usage, options, and expected log markers.
- Scripts:
  - scripts/test-deployment.sh: Lowers SPEND_THRESHOLD, invokes Lambda, scans CW logs, restores env.
  - scripts/verify-deployed-bundle.sh: Downloads live Lambda code and scans for unexpected modules.
- package.json:
  - Adds npm run test:deployment → scripts/test-deployment.sh.
- deploy.sh:
  - Syncs dist/ → fresh-deployment/ after build.
  - Installs production-only dependencies in fresh-deployment to reduce Lambda bundle size.
  - Fails fast if “strands-agents” is found in artifacts.
- scripts/pre-deployment-check.sh:
  - Removes “strands-agents” as required dep; adds guard to scan for stray references in dist/ and fresh-deployment/.
- jest.config.js / tests/setup.ts:
  - Disables watchman; uses a virtual mock for 'strands-agents' to avoid module resolution errors in tests.

Rationale
- Prevents stale-code deployment issues (e.g., Cannot find module 'strands-agents').
- Improves reliability of Lambda packaging (size constraints) and adds turnkey verification.
- Provides reproducible steps to validate alerts and SNS delivery in a live account.

How to Test
- Build + deploy:
  - npm ci && npm run build && ./deploy.sh --skip-tests
- Verify live bundle:
  - npm run verify:lambda-bundle -- SpendMonitorStack-SpendMonitorAgentV2-<id>
- Force alert path and scan logs:
  - npm run test:deployment
- Manual re-invoke:
  - aws lambda invoke --function-name <LambdaName> --payload '{}' response.json && cat response.json
- SNS delivery check:
  - aws sns list-subscriptions-by-topic --topic-arn <TopicArn>
  - aws cloudwatch get-metric-statistics --namespace AWS/SNS --metric-name NumberOfNotificationsDelivered ...

Expected Outcomes
- Lambda invocations return 200 with healthCheck: "healthy".
- Logs show “Spending threshold exceeded” and “Alert sent successfully” when threshold is lowered.
- SNS “NumberOfNotificationsDelivered” metric increments; confirmed email endpoints receive messages.

CDK/IaC Impact
- No resource name changes; same stack and function names.
- Packaging source remains Code.fromAsset('fresh-deployment'); content is now synced from dist/ and pruned to prod deps.
- Rollback: revert branch; optionally redeploy to repackage Lambda from previous flow.

Config Validation
- Pre-deploy: npm run validate:pre-deploy ensures build, dependency, and artifact checks (including stray “strands-agents”).

